### PR TITLE
feat: add demo endpoints

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -31,3 +31,10 @@ NocoDB
 logtest
 oneshot
 Stuckee
+dtstart
+rrule
+byday
+vertipad
+seccomp
+Lcov
+itest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,8 +2313,8 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svc-gis-client-grpc"
-version = "0.1.1-develop.6"
-source = "git+https://github.com/Arrow-air/svc-gis.git?branch=am-smith/get-flights-grpc#2503556d268d3496d4fc80fa2ae8c3825a860cef"
+version = "0.1.1-develop.7"
+source = "git+https://github.com/Arrow-air/svc-gis.git?tag=latest-develop#c659ef092308c5b2428c95a45162bab2c78453a1"
 dependencies = [
  "cfg-if",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -68,43 +68,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "approx"
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "array-init"
@@ -129,45 +129,24 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrow-macros-core"
-version = "0.1.1-develop.2"
-source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.1.1-develop.2#c7e0fc4918d3346a13ab84e2d4fc16d430a60c59"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "arrow-macros-core"
 version = "0.2.1-develop.0"
 source = "git+https://github.com/Arrow-air/lib-common?tag=latest-develop#4ccaa5c1e59f5c8dc2a5efd97b7f17e0e6fa1692"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "arrow-macros-core"
 version = "0.2.1-develop.0"
-source = "git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
+source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "arrow-macros-derive"
-version = "0.1.1-develop.2"
-source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.1.1-develop.2#c7e0fc4918d3346a13ab84e2d4fc16d430a60c59"
-dependencies = [
- "arrow-macros-core 0.1.1-develop.2",
- "proc-macro-error",
- "proc-macro2",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -183,9 +162,9 @@ dependencies = [
 [[package]]
 name = "arrow-macros-derive"
 version = "0.2.1-develop.0"
-source = "git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
+source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
 dependencies = [
- "arrow-macros-core 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0)",
+ "arrow-macros-core 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0)",
  "proc-macro-error",
  "proc-macro2",
 ]
@@ -209,25 +188,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
@@ -353,18 +332,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
-dependencies = [
- "serde",
-]
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -374,9 +344,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -389,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -413,12 +383,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -428,9 +395,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -438,14 +405,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -453,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -465,21 +432,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -488,10 +455,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "config"
-version = "0.13.3"
+name = "combine"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "config"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
 dependencies = [
  "async-trait",
  "json5",
@@ -502,15 +479,15 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -518,24 +495,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -637,15 +614,15 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
 dependencies = [
- "itertools 0.11.0",
+ "itertools",
  "num-traits",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "equivalent"
@@ -655,21 +632,21 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "2b73807008a3c7f171cc40312f37d95ef0396e048b5848d775f54b1a4dd4a0d3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -735,18 +712,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -759,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -769,15 +746,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -786,38 +763,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -859,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9705398c5c7b26132e74513f4ee7c1d7dafd786004991b375c172be2be0eecaa"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
 dependencies = [
  "approx",
  "num-traits",
@@ -871,18 +848,18 @@ dependencies = [
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea804e7bd3c6a4ca6a01edfa35231557a8a81d4d3f3e1e2b650d028c42592be"
+checksum = "e6e5ed84f8089c70234b0a8e0aedb6dc733671612ddc0d37c6066052f9781960"
 dependencies = [
- "lazy_static",
+ "libm",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -891,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -903,9 +880,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -913,7 +890,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -940,15 +917,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -964,10 +941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hmac"
@@ -980,18 +963,18 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1000,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -1035,9 +1018,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1050,7 +1033,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -1071,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1093,6 +1076,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,29 +1097,20 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
 [[package]]
 name = "inventory"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itertools"
@@ -1139,15 +1123,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1171,22 +1155,6 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib-common"
-version = "0.1.1-develop.2"
-source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.1.1-develop.2#c7e0fc4918d3346a13ab84e2d4fc16d430a60c59"
-dependencies = [
- "arrow-macros-derive 0.1.1-develop.2",
- "cargo-husky",
- "chrono",
- "futures",
- "log",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "tonic 0.8.3",
- "trybuild",
-]
-
-[[package]]
-name = "lib-common"
 version = "0.2.1-develop.0"
 source = "git+https://github.com/Arrow-air/lib-common?tag=latest-develop#4ccaa5c1e59f5c8dc2a5efd97b7f17e0e6fa1692"
 dependencies = [
@@ -1197,10 +1165,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "prost 0.12.1",
+ "prost",
  "prost-wkt-types",
  "tokio",
- "tonic 0.10.2",
+ "tonic",
  "tower",
  "trybuild",
 ]
@@ -1208,28 +1176,24 @@ dependencies = [
 [[package]]
 name = "lib-common"
 version = "0.2.1-develop.0"
-source = "git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
+source = "git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0#ab297fda939b316ad4778dba2711e626246e048b"
 dependencies = [
- "arrow-macros-derive 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0)",
+ "arrow-macros-derive 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0)",
  "cargo-husky",
  "chrono",
  "futures",
- "http",
- "hyper",
  "log",
- "prost 0.12.1",
+ "prost",
  "prost-wkt-types",
- "tokio",
- "tonic 0.10.2",
- "tower",
+ "tonic",
  "trybuild",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -1245,9 +1209,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1261,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
  "value-bag",
@@ -1277,9 +1241,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1291,11 +1255,13 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
+ "once_cell",
  "parking_lot",
+ "rand",
  "serde",
  "serde-value",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "thread-id",
  "typemap-ors",
@@ -1336,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -1354,22 +1320,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1408,20 +1374,20 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -1439,26 +1405,26 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1475,7 +1441,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1486,18 +1452,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.5+3.1.3"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -1517,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -1552,9 +1518,9 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1571,15 +1537,15 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1588,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.4"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1598,22 +1564,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.4"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.4"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -1627,7 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -1650,22 +1616,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1682,9 +1648,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "postgis"
@@ -1695,6 +1661,18 @@ dependencies = [
  "byteorder",
  "bytes",
  "postgres-types",
+]
+
+[[package]]
+name = "postgres-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1716,7 +1694,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -1739,6 +1717,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "geo-types",
+ "postgres-derive",
  "postgres-protocol",
  "serde",
  "serde_json",
@@ -1753,12 +1732,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1787,99 +1766,67 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
-dependencies = [
- "bytes",
- "prost-derive 0.12.1",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck",
- "itertools 0.11.0",
+ "heck 0.4.1",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.1",
- "prost-types 0.12.1",
+ "prost",
+ "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.38",
+ "syn 2.0.53",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
-dependencies = [
- "prost 0.12.1",
+ "prost",
 ]
 
 [[package]]
@@ -1890,7 +1837,7 @@ checksum = "4d8ef9c3f0f1dab910d2b7e2c24a8e4322e122eba6d7a1921eeebcebbc046c40"
 dependencies = [
  "chrono",
  "inventory",
- "prost 0.12.1",
+ "prost",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1903,10 +1850,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b31cae9a54ca84fee1504740a82eebf2479532905e106f63ca0c3bc8d780321"
 dependencies = [
- "heck",
- "prost 0.12.1",
+ "heck 0.4.1",
+ "prost",
  "prost-build",
- "prost-types 0.12.1",
+ "prost-types",
  "quote",
 ]
 
@@ -1917,9 +1864,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435be4a8704091b4c5fb1d79799de7f2dbff53af05edf29385237f8cf7ab37ee"
 dependencies = [
  "chrono",
- "prost 0.12.1",
+ "prost",
  "prost-build",
- "prost-types 0.12.1",
+ "prost-types",
  "prost-wkt",
  "prost-wkt-build",
  "regex",
@@ -1930,11 +1877,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "memchr",
  "unicase",
 ]
@@ -1950,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1988,12 +1935,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
+name = "redis"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
 dependencies = [
- "bitflags 1.3.2",
+ "combine",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "url",
 ]
 
 [[package]]
@@ -2007,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2019,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2089,15 +2042,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2108,17 +2061,17 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2152,15 +2105,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -2177,23 +2130,32 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
  "serde",
 ]
 
@@ -2211,28 +2173,22 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
-dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -2271,15 +2227,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -2287,12 +2243,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2323,9 +2279,31 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.53",
+]
 
 [[package]]
 name = "subtle"
@@ -2334,9 +2312,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "svc-gis-client-grpc"
+version = "0.1.1-develop.6"
+source = "git+https://github.com/Arrow-air/svc-gis.git?branch=am-smith/get-flights-grpc#2503556d268d3496d4fc80fa2ae8c3825a860cef"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common.git?tag=v0.2.1-develop.0)",
+ "log",
+ "num-derive",
+ "num-traits",
+ "postgres-types",
+ "prost",
+ "prost-types",
+ "redis",
+ "serde",
+ "serde_json",
+ "strum",
+ "tonic",
+ "uuid",
+]
+
+[[package]]
+name = "svc-itest"
+version = "0.2.0-develop.7"
+dependencies = [
+ "anyhow",
+ "axum 0.5.17",
+ "cargo-husky",
+ "chrono",
+ "clap",
+ "config",
+ "dotenv",
+ "hyper",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
+ "log",
+ "log4rs",
+ "logtest",
+ "openssl",
+ "prost",
+ "serde",
+ "serde_json",
+ "svc-gis-client-grpc",
+ "svc-itest",
+ "svc-storage-client-grpc",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tonic-health",
+ "tower",
+ "tower-http 0.4.4",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "svc-itest-client-grpc"
+version = "0.2.0-develop.7"
+dependencies = [
+ "cfg-if",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
+ "log",
+ "logtest",
+ "prost",
+ "svc-itest",
+ "svc-itest-client-grpc",
+ "tokio",
+ "tonic",
+ "tower",
+]
+
+[[package]]
+name = "svc-itest-client-rest"
+version = "0.2.0-develop.7"
+dependencies = [
+ "chrono",
+ "hyper",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
+ "serde",
+ "serde_json",
+ "tokio",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "svc-storage"
-version = "0.11.1-develop.0"
-source = "git+https://github.com/Arrow-air/svc-storage?tag=latest-develop#459c8c3e92feaefe732a6205f96e0ebfca64bb0a"
+version = "0.11.1-develop.7"
+source = "git+https://github.com/Arrow-air/svc-storage.git?tag=latest-develop#8baec86c3ae5233a36210810ccc5226cfa323a64"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2354,7 +2418,7 @@ dependencies = [
  "geo-types",
  "hyper",
  "lazy_static",
- "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0)",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
  "log",
  "log4rs",
  "native-tls",
@@ -2366,18 +2430,18 @@ dependencies = [
  "postgis",
  "postgres-native-tls",
  "postgres-types",
- "prost 0.12.1",
- "prost-types 0.12.1",
+ "prost",
+ "prost-types",
  "prost-wkt-types",
  "rand",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-postgres",
  "tokio-util",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "tonic-health",
  "uuid",
@@ -2385,105 +2449,30 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.11.1-develop.0"
-source = "git+https://github.com/Arrow-air/svc-storage?tag=latest-develop#459c8c3e92feaefe732a6205f96e0ebfca64bb0a"
+version = "0.11.1-develop.7"
+source = "git+https://github.com/Arrow-air/svc-storage.git?tag=latest-develop#8baec86c3ae5233a36210810ccc5226cfa323a64"
 dependencies = [
  "anyhow",
  "cfg-if",
  "futures",
  "geo-types",
  "lazy_static",
- "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=v0.2.1-develop.0)",
+ "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
  "log",
  "num-derive",
  "num-traits",
- "ordered-float 4.1.1",
+ "ordered-float 4.2.0",
  "paste",
- "prost 0.12.1",
- "prost-types 0.12.1",
+ "prost",
+ "prost-types",
  "prost-wkt-types",
  "serde",
  "serde_json",
  "svc-storage",
  "tokio",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "tower",
- "utoipa",
- "uuid",
-]
-
-[[package]]
-name = "svc-template-rust"
-version = "0.2.0-develop.7"
-dependencies = [
- "anyhow",
- "axum 0.5.17",
- "cargo-husky",
- "chrono",
- "clap",
- "config",
- "dotenv",
- "hyper",
- "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
- "log",
- "log4rs",
- "logtest",
- "openssl",
- "prost 0.12.1",
- "serde",
- "serde_json",
- "svc-storage-client-grpc",
- "svc-template-rust",
- "svc-template-rust-client-grpc 0.2.0-develop.4",
- "tokio",
- "tokio-util",
- "tonic 0.10.2",
- "tonic-build",
- "tonic-health",
- "tower",
- "tower-http 0.4.4",
- "utoipa",
-]
-
-[[package]]
-name = "svc-template-rust-client-grpc"
-version = "0.2.0-develop.4"
-source = "git+https://github.com/Arrow-air/svc-template-rust.git?tag=v0.2.0-develop.4#8056706bc214158644d80fa8a8662a01e0c5db5f"
-dependencies = [
- "lib-common 0.1.1-develop.2",
- "log",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "tonic 0.8.3",
-]
-
-[[package]]
-name = "svc-template-rust-client-grpc"
-version = "0.2.0-develop.7"
-dependencies = [
- "cfg-if",
- "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
- "log",
- "logtest",
- "prost 0.12.1",
- "svc-template-rust",
- "svc-template-rust-client-grpc 0.2.0-develop.7",
- "tokio",
- "tonic 0.10.2",
- "tower",
-]
-
-[[package]]
-name = "svc-template-rust-client-rest"
-version = "0.2.0-develop.7"
-dependencies = [
- "chrono",
- "hyper",
- "lib-common 0.2.1-develop.0 (git+https://github.com/Arrow-air/lib-common?tag=latest-develop)",
- "serde",
- "serde_json",
- "tokio",
  "utoipa",
  "uuid",
 ]
@@ -2501,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2518,44 +2507,43 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2585,9 +2573,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2597,9 +2585,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2614,13 +2602,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2653,7 +2641,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tokio",
  "tokio-util",
  "whoami",
@@ -2661,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2672,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2694,36 +2682,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.8.3"
+name = "toml"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.13.1",
- "bytes",
- "flate2",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+dependencies = [
+ "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2735,7 +2724,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.6.20",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bytes",
  "flate2",
  "h2",
@@ -2745,7 +2734,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.1",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
@@ -2764,7 +2753,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2774,10 +2763,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
 dependencies = [
  "async-stream",
- "prost 0.12.1",
+ "prost",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic",
 ]
 
 [[package]]
@@ -2825,7 +2814,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2852,9 +2841,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2870,7 +2859,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2883,34 +2872,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
+name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.85"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196a58260a906cedb9bf6d8034b6379d0c11f552416960452f267402ceeddff1"
+checksum = "2aa6f84ec205ebf87fb7a0abdbcd1467fa5af0e86878eb6d888b78ecbb10b6d5"
 dependencies = [
- "basic-toml",
  "glob",
  "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -2930,9 +2909,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typetag"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80960fd143d4c96275c0e60b08f14b81fbb468e79bc0ef8fbda69fb0afafae43"
+checksum = "661d18414ec032a49ece2d56eee03636e43c4e8d577047ab334c0ba892e29aaf"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -2943,13 +2922,13 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc13d450dc4a695200da3074dacf43d449b968baee95e341920e47f61a3b40f"
+checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2969,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -2981,9 +2960,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -2999,9 +2978,20 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -3011,11 +3001,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b208a50ff438dcdc887ea3f2db59530bd2f4bc3d2c70630e4d7ee7a281a1d1b"
+checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -3023,31 +3013,32 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd516d8879043e081537690bc96c8f17b5a4602c336aecb8f1de89d9d9c7e72"
+checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.38",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "8fec26a25bd6fca441cdd0f769fd7f891bae119f996de31f86a5eddccef54c1d"
 
 [[package]]
 name = "vcpkg"
@@ -3077,10 +3068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
+name = "wasite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3088,24 +3085,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3113,28 +3110,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3154,11 +3151,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall",
+ "wasite",
  "web-sys",
 ]
 
@@ -3195,11 +3193,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3208,7 +3206,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3217,13 +3224,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -3233,10 +3255,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3245,10 +3279,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3257,16 +3303,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [workspace]
-members = ["server", "client-grpc", "client-rest"]
+members  = ["server", "client-grpc", "client-rest"]
+resolver = "2"
 
 [workspace.package]
 authors      = ["arrow-services <group-services@arrowair.com>"]
 edition      = "2021"
 homepage     = "https://www.arrowair.com/docs/documentation/services/intro"
 license-file = "LICENSE"
-repository   = "https://github.com/Arrow-air/svc-template-rust"
+repository   = "https://github.com/Arrow-air/svc-itest"
 
 categories = [
   "aerospace::drones",

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 1. *Replace the repository name for each:*
 
-![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-template-rust/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-template-rust)
-![Sanity Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-template-rust/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
+![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-itest/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-itest)
+![Sanity Checks](https://github.com/arrow-air/svc-itest/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-itest/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-itest/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
 ![Arrow DAO Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
 
 2. *Grep for 'template' in all files, replace with name of this service*
     ```bash
-    grep -Ri template_rust
-    grep -Ri template-rust
+    grep -Ri itest
+    grep -Ri itest
     ```
 3. *Remove this and previous numbered bullets*
 
@@ -119,7 +119,7 @@ Learn more about us:
 
 ## LICENSE Notice
 
-Please note that svc-template-rust is under BUSL license until the Change Date, currently the earlier of two years from the release date. Exceptions to the license may be specified by Arrow Governance via Additional Use Grants, which can, for example, allow svc-template-rust to be deployed for certain production uses. Please reach out to Arrow DAO to request a DAO vote for exceptions to the license, or to move up the Change Date.
+Please note that svc-itest is under BUSL license until the Change Date, currently the earlier of two years from the release date. Exceptions to the license may be specified by Arrow Governance via Additional Use Grants, which can, for example, allow svc-itest to be deployed for certain production uses. Please reach out to Arrow DAO to request a DAO vote for exceptions to the license, or to move up the Change Date.
 
 ## :exclamation: Treatment of `Cargo.lock`
 If you are building a non-end product like a library, include `Cargo.lock` in `.gitignore`.

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-description = "Arrow template-rust service gRPC client"
-keywords    = ["vtol", "client", "grpc", "template-rust"] # max 5
-name        = "svc-template-rust-client-grpc"
+description = "Arrow itest service gRPC client"
+keywords    = ["vtol", "client", "grpc", "itest"] # max 5
+name        = "svc-itest-client-grpc"
 version     = "0.2.0-develop.7"
 
 authors.workspace      = true
@@ -17,21 +17,17 @@ test_util = ["mock", "stub_backends", "tokio"]
 # Will add a 'mock' module for the enabled resources, providing access to mock data generation functions
 mock = []
 # Will use a stubbed server connection, only use for tests!
-stub_backends = [
-  "svc-template-rust/stub_server",
-  "lib-common/grpc_mock",
-  "tower",
-]
+stub_backends = ["svc-itest/stub_server", "lib-common/grpc_mock", "tower"]
 # Will implement stub functions for the client, only use for tests!
-stub_client = ["svc-template-rust"]
+stub_client = ["svc-itest"]
 
 [dependencies]
-cfg-if            = "1.0"
-log               = { version = "0.4" }
-prost             = "0.12"
-svc-template-rust = { path = "../server", optional = true }
-tonic             = "0.10"
-tower             = { version = "0.4", optional = true }
+cfg-if    = "1.0"
+log       = { version = "0.4" }
+prost     = "0.12"
+svc-itest = { path = "../server", optional = true }
+tonic     = "0.10"
+tower     = { version = "0.4", optional = true }
 
 [dependencies.lib-common]
 features = ["grpc"]
@@ -47,7 +43,7 @@ version  = "1.33"
 logtest = "2.0"
 
 # Make sure we enable the required modules for testing
-[dev-dependencies.svc-template-rust-client-grpc]
+[dev-dependencies.svc-itest-client-grpc]
 features = ["dev"]
 path     = "."
 

--- a/client-grpc/README.md
+++ b/client-grpc/README.md
@@ -1,11 +1,11 @@
 ![Arrow Banner](https://github.com/Arrow-air/tf-github/raw/main/src/templates/doc-banner-services.png)
 
-# svc-template-rust gRPC Client
+# svc-itest gRPC Client
 
-![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-template-rust/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-template-rust)
-![Sanity Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-template-rust/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
+![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-itest/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-itest)
+![Sanity Checks](https://github.com/arrow-air/svc-itest/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-itest/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-itest/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
 ![Arrow DAO Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
 
 ## Overview
 
-Exposes svc-template-rust gRPC client functions
+Exposes svc-itest gRPC client functions

--- a/client-grpc/examples/grpc.rs
+++ b/client-grpc/examples/grpc.rs
@@ -1,20 +1,20 @@
 //! gRPC client implementation
 
 use lib_common::grpc::get_endpoint_from_env;
-use svc_template_rust_client_grpc::prelude::*;
+use svc_itest_client_grpc::prelude::*;
 
-/// Example svc-template-rust-client-grpc
+/// Example svc-itest-client-grpc
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (host, port) = get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
-    let client = TemplateRustClient::new_client(&host, port, "template_rust");
+    let client = TemplateRustClient::new_client(&host, port, "itest");
     println!("Client created.");
     println!(
         "NOTE: Ensure the server is running on {} or this example will fail.",
         client.get_address()
     );
 
-    let response = client.is_ready(template_rust::ReadyRequest {}).await?;
+    let response = client.is_ready(itest::ReadyRequest {}).await?;
 
     println!("RESPONSE={:?}", response.into_inner());
 

--- a/client-grpc/src/client.rs
+++ b/client-grpc/src/client.rs
@@ -13,12 +13,12 @@ pub type TemplateRustClient = GrpcClient<RpcServiceClient<Channel>>;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "stub_backends")] {
-        use svc_template_rust::grpc::server::{RpcServiceServer, ServerImpl};
+        use svc_itest::grpc::server::{RpcServiceServer, ServerImpl};
         lib_common::grpc_mock_client!(RpcServiceClient, RpcServiceServer, ServerImpl);
-        super::log_macros!("grpc", "app::client::mock::template_rust");
+        super::log_macros!("grpc", "app::client::mock::itest");
     } else {
         lib_common::grpc_client!(RpcServiceClient);
-        super::log_macros!("grpc", "app::client::template_rust");
+        super::log_macros!("grpc", "app::client::itest");
     }
 }
 
@@ -63,7 +63,7 @@ mod tests {
     #[tokio::test]
     #[cfg(not(feature = "stub_client"))]
     async fn test_client_connect() {
-        let name = "template_rust";
+        let name = "itest";
         let (server_host, server_port) =
             lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
 
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_is_ready_request() {
-        let name = "template_rust";
+        let name = "itest";
         let (server_host, server_port) =
             lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
 

--- a/client-grpc/src/prelude.rs
+++ b/client-grpc/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Re-export of used objects
 
-pub use super::client as template_rust;
+pub use super::client as itest;
 pub use super::service::Client as TemplateRustServiceClient;
-pub use template_rust::TemplateRustClient;
+pub use itest::TemplateRustClient;
 
 pub use lib_common::grpc::Client;

--- a/client-grpc/src/service.rs
+++ b/client-grpc/src/service.rs
@@ -22,13 +22,13 @@ where
     /// # Examples
     /// ```
     /// use lib_common::grpc::get_endpoint_from_env;
-    /// use svc_template_rust_client_grpc::prelude::*;
+    /// use svc_itest_client_grpc::prelude::*;
     ///
     /// async fn example () -> Result<(), Box<dyn std::error::Error>> {
     ///     let (host, port) = get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
-    ///     let client = TemplateRustClient::new_client(&host, port, "template_rust");
+    ///     let client = TemplateRustClient::new_client(&host, port, "itest");
     ///     let response = client
-    ///         .is_ready(template_rust::ReadyRequest {})
+    ///         .is_ready(itest::ReadyRequest {})
     ///         .await?;
     ///     println!("RESPONSE={:?}", response.into_inner());
     ///     Ok(())

--- a/client-grpc/tests/integration_test.rs
+++ b/client-grpc/tests/integration_test.rs
@@ -18,9 +18,9 @@ fn get_log_string(function: &str, name: &str) -> String {
 async fn test_client_requests_and_logs() {
     use logtest::Logger;
 
-    use svc_template_rust_client_grpc::prelude::*;
+    use svc_itest_client_grpc::prelude::*;
 
-    let name = "template_rust";
+    let name = "itest";
     let (server_host, server_port) =
         lib_common::grpc::get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
 
@@ -31,7 +31,7 @@ async fn test_client_requests_and_logs() {
 
     //test_is_ready_request_logs
     {
-        let result = client.is_ready(template_rust::ReadyRequest {}).await;
+        let result = client.is_ready(itest::ReadyRequest {}).await;
         println!("{:?}", result);
         assert!(result.is_ok());
 

--- a/client-rest/Cargo.toml
+++ b/client-rest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-description = "Arrow template-rust service REST client"
-keywords    = ["vtol", "client", "rest", "template-rust"] # max 5
-name        = "svc-template-rust-client-rest"
+description = "Arrow itest service REST client"
+keywords    = ["vtol", "client", "rest", "itest"] # max 5
+name        = "svc-itest-client-rest"
 version     = "0.2.0-develop.7"
 
 authors.workspace      = true

--- a/client-rest/README.md
+++ b/client-rest/README.md
@@ -1,11 +1,11 @@
 ![Arrow Banner](https://github.com/Arrow-air/tf-github/raw/main/src/templates/doc-banner-services.png)
 
-# svc-template-rust REST Client
+# svc-itest REST Client
 
-![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-template-rust/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-template-rust)
-![Sanity Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-template-rust/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
+![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-itest/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-itest)
+![Sanity Checks](https://github.com/arrow-air/svc-itest/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-itest/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-itest/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
 ![Arrow DAO Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
 
 ## Overview
 
-Exposes svc-template-rust REST API functions
+Exposes svc-itest REST API functions

--- a/client-rest/examples/rest.rs
+++ b/client-rest/examples/rest.rs
@@ -1,29 +1,26 @@
 //! Example communication with this service
 
-use chrono::Utc;
-use hyper::{Body, Client, Method, Request, Response};
-use hyper::{Error, StatusCode};
 use lib_common::grpc::get_endpoint_from_env;
-use svc_template_rust_client_rest::types::*;
+// use svc_itest_client_rest::types::*;
 
-fn evaluate(resp: Result<Response<Body>, Error>, expected_code: StatusCode) -> (bool, String) {
-    let mut ok = true;
-    let result_str: String = match resp {
-        Ok(r) => {
-            let tmp = r.status() == expected_code;
-            ok &= tmp;
-            println!("{:?}", r.body());
+// fn evaluate(resp: Result<Response<Body>, Error>, expected_code: StatusCode) -> (bool, String) {
+//     let mut ok = true;
+//     let result_str: String = match resp {
+//         Ok(r) => {
+//             let tmp = r.status() == expected_code;
+//             ok &= tmp;
+//             println!("{:?}", r.body());
 
-            r.status().to_string()
-        }
-        Err(e) => {
-            ok = false;
-            e.to_string()
-        }
-    };
+//             r.status().to_string()
+//         }
+//         Err(e) => {
+//             ok = false;
+//             e.to_string()
+//         }
+//     };
 
-    (ok, result_str)
-}
+//     (ok, result_str)
+// }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -34,32 +31,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Rest endpoint set to [{url}].");
 
-    let mut ok = true;
-    let client = Client::builder()
-        .pool_idle_timeout(std::time::Duration::from_secs(10))
-        .build_http();
+    let ok = true;
+    // let client = Client::builder()
+    //     .pool_idle_timeout(std::time::Duration::from_secs(10))
+    //     .build_http();
 
     // POST /template/example
     {
-        let data = ExampleRequest {
-            id: "abcdef12".to_string(),
-            timestamp: Utc::now(),
-        };
+        // let data = ExampleRequest {
+        //     id: "abcdef12".to_string(),
+        //     timestamp: Utc::now(),
+        // };
 
-        let data_str = serde_json::to_string(&data).unwrap();
-        let uri = format!("{}/template/example", url);
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri(uri.clone())
-            .header("content-type", "application/json")
-            .body(Body::from(data_str))
-            .unwrap();
+        // let data_str = serde_json::to_string(&data).unwrap();
+        // let uri = format!("{}/template/example", url);
+        // let req = Request::builder()
+        //     .method(Method::POST)
+        //     .uri(uri.clone())
+        //     .header("content-type", "application/json")
+        //     .body(Body::from(data_str))
+        //     .unwrap();
 
-        let resp = client.request(req).await;
-        let (success, result_str) = evaluate(resp, StatusCode::OK);
-        ok &= success;
+        // let resp = client.request(req).await;
+        // let (success, result_str) = evaluate(resp, StatusCode::OK);
+        // ok &= success;
 
-        println!("{}: {}", uri, result_str);
+        // println!("{}: {}", uri, result_str);
     }
 
     if ok {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+configs:
+  log4rs:
+    file: log4rs.yaml
+  dot-env:
+    file: .env
+
+services:
+  web-server:
+    extends:
+      file: docker-compose-base.yml
+      service: web-server
+    environment:
+      - STORAGE_HOST_GRPC=svc-storage
+      - STORAGE_PORT_GRPC
+      - GIS_HOST_GRPC=svc-gis
+      - GIS_PORT_GRPC
+      - REQUEST_LIMIT_PER_SECOND
+
+  example:
+    extends:
+      file: docker-compose-base.yml
+      service: example
+
+  ut-coverage:
+    extends:
+      file: docker-compose-base.yml
+      service: ut-coverage
+
+  it-coverage:
+    extends:
+      file: docker-compose-base.yml
+      service: it-coverage

--- a/openapi/types.rs
+++ b/openapi/types.rs
@@ -2,27 +2,51 @@
 
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
-use chrono::{DateTime, Utc};
 
-/// Example Request Body Information Type
+/// Information needed to build a vertipad
 #[derive(Debug, Clone)]
 #[derive(Deserialize, Serialize)]
 #[derive(ToSchema, IntoParams)]
-pub struct ExampleRequest {
-    /// Itinerary UUID to Cancel
-    pub id: String,
+pub struct Vertipad {
+    /// The latitude of the pad
+    pub centroid_latitude: f64,
+    
+    /// The longitude of the pad
+    pub centroid_longitude: f64,
 
-    /// The time of the request
-    pub timestamp: DateTime<Utc>
+    /// The radius of the pad in meters
+    pub radius_meters: f32,
+
+    /// The informal label for this pad
+    pub label: String
 }
 
-/// Confirm itinerary Operation Status
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub enum ExampleStatus {
-    /// Unauthorized request
-    #[schema(example = "Unauthorized request.")]
-    Unauthorized(String),
+/// Information needed to add a vertiport
+#[derive(Debug, Clone)]
+#[derive(Deserialize, Serialize)]
+#[derive(ToSchema, IntoParams)]
+pub struct AddVertiportRequest {
+    /// The label of the vertiport
+    pub label: String,
 
-    /// Unavailable Service
-    Unavailable,
+    /// The bounding polygon of this vertiport
+    pub vertices: Vec<(f64, f64)>,
+
+    /// The pads at this vertiport
+    pub pads: Vec<Vertipad>
+}
+
+/// Information needed to add an aircraft
+#[derive(Debug, Clone)]
+#[derive(Deserialize, Serialize)]
+#[derive(ToSchema, IntoParams)]
+pub struct AddAircraftRequest {
+    /// The nickname of the aircraft
+    pub nickname: String,
+
+    /// The registration number of the aircraft
+    pub registration_number: String,
+
+    /// The hangar ID
+    pub hangar_id: String
 }

--- a/openapi/types.rs
+++ b/openapi/types.rs
@@ -7,15 +7,15 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Debug, Clone)]
 #[derive(Deserialize, Serialize)]
 #[derive(ToSchema, IntoParams)]
-pub struct Vertipad {
+pub struct AddVertipadRequest {
+    /// The ID of the vertiport
+    pub vertiport_id: String,
+
     /// The latitude of the pad
-    pub centroid_latitude: f64,
+    pub latitude: f64,
     
     /// The longitude of the pad
-    pub centroid_longitude: f64,
-
-    /// The radius of the pad in meters
-    pub radius_meters: f32,
+    pub longitude: f64,
 
     /// The informal label for this pad
     pub label: String
@@ -30,10 +30,7 @@ pub struct AddVertiportRequest {
     pub label: String,
 
     /// The bounding polygon of this vertiport
-    pub vertices: Vec<(f64, f64)>,
-
-    /// The pads at this vertiport
-    pub pads: Vec<Vertipad>
+    pub vertices: Vec<(f64, f64)>
 }
 
 /// Information needed to add an aircraft
@@ -48,5 +45,18 @@ pub struct AddAircraftRequest {
     pub registration_number: String,
 
     /// The hangar ID
-    pub hangar_id: String
+    pub hangar_id: String,
+
+    /// The hangar bay ID
+    pub hangar_bay_id: String
+}
+
+
+/// Information needed to build a vertipad
+#[derive(Debug, Clone)]
+#[derive(Deserialize, Serialize)]
+#[derive(ToSchema, IntoParams)]
+pub struct AddUserRequest {
+    /// The display name of the user
+    pub display_name: String,
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Arrow template service gRPC server"
-keywords    = ["vtol", "server", "grpc", "rest", "template-rust"] # max 5
-name        = "svc-template-rust"
+keywords    = ["vtol", "server", "grpc", "rest", "itest"] # max 5
+name        = "svc-itest"
 version     = "0.2.0-develop.7"
 
 authors.workspace      = true
@@ -49,19 +49,17 @@ tonic        = "0.10"
 tonic-health = "0.10"
 tower        = { version = "0.4", features = ["limit"] }
 tower-http   = { version = "0.4", features = ["cors", "trace"] }
+uuid         = { version = "1.7.0", features = ["v4", "serde"] }
 
-# ========================================================
-# FIXME: This is used as an example, you can point to other services's clients instead.
-# ========================================================
-[dependencies.svc-template-rust-client-grpc]
-git = "https://github.com/Arrow-air/svc-template-rust.git"
-tag = "v0.2.0-develop.4"
+[dependencies.svc-gis-client-grpc]
+git = "https://github.com/Arrow-air/svc-gis.git"
+# tag = "v0.2.0-develop.4"
+branch = "am-smith/get-flights-grpc"
 
 [dependencies.svc-storage-client-grpc]
-features = ["adsb"]
-git      = "https://github.com/Arrow-air/svc-storage"
+features = ["vertiport", "vertipad", "vehicle", "user"]
+git      = "https://github.com/Arrow-air/svc-storage.git"
 tag      = "latest-develop"
-# ========================================================
 
 [dependencies.lib-common]
 git = "https://github.com/Arrow-air/lib-common"
@@ -89,7 +87,7 @@ features         = ["user-hooks"]
 version          = "1"
 
 # Make sure we enable the required modules when running tests
-[dev-dependencies.svc-template-rust]
+[dev-dependencies.svc-itest]
 features = ["dev"]
 path     = "."
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,8 +53,7 @@ uuid         = { version = "1.7.0", features = ["v4", "serde"] }
 
 [dependencies.svc-gis-client-grpc]
 git = "https://github.com/Arrow-air/svc-gis.git"
-# tag = "v0.2.0-develop.4"
-branch = "am-smith/get-flights-grpc"
+tag = "latest-develop"
 
 [dependencies.svc-storage-client-grpc]
 features = ["vertiport", "vertipad", "vehicle", "user"]

--- a/server/README.md
+++ b/server/README.md
@@ -1,9 +1,9 @@
 ![Arrow Banner](https://github.com/Arrow-air/tf-github/raw/main/src/templates/doc-banner-services.png)
 
-# svc-template-rust Service
+# svc-itest Service
 
-![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-template-rust?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-template-rust/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-template-rust)
-![Sanity Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-template-rust/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-template-rust/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
+![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?sort=semver&color=green) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/svc-itest?include_prereleases) [![Coverage Status](https://coveralls.io/repos/github/Arrow-air/svc-itest/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/svc-itest)
+![Sanity Checks](https://github.com/arrow-air/svc-itest/actions/workflows/sanity_checks.yml/badge.svg?branch=develop) ![Python PEP8](https://github.com/arrow-air/svc-itest/actions/workflows/python_ci.yml/badge.svg?branch=develop) ![Rust Checks](https://github.com/arrow-air/svc-itest/actions/workflows/rust_ci.yml/badge.svg?branch=develop) 
 ![Arrow DAO Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
 
 ## Overview

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -18,6 +18,10 @@ pub struct Config {
     pub storage_host_grpc: String,
     /// port of storage server
     pub storage_port_grpc: u16,
+    /// gis server
+    pub gis_host_grpc: String,
+    /// gis port
+    pub gis_port_grpc: u16,
     /// path to log configuration YAML file
     pub log_config: String,
     /// Rate limit - requests per second for REST requests
@@ -44,6 +48,8 @@ impl Config {
             docker_port_rest: 8000,
             storage_port_grpc: 50051,
             storage_host_grpc: String::from("svc-storage"),
+            gis_host_grpc: String::from("svc-gis"),
+            gis_port_grpc: 50052,
             log_config: String::from("log4rs.yaml"),
             rest_request_limit_per_second: 2,
             rest_concurrency_limit_per_service: 5,
@@ -94,6 +100,8 @@ mod tests {
         assert_eq!(config.docker_port_rest, 8000);
         assert_eq!(config.storage_port_grpc, 50051);
         assert_eq!(config.storage_host_grpc, String::from("svc-storage"));
+        assert_eq!(config.gis_host_grpc, String::from("svc-gis"));
+        assert_eq!(config.gis_port_grpc, 50052);
         assert_eq!(config.log_config, String::from("log4rs.yaml"));
         assert_eq!(config.rest_concurrency_limit_per_service, 5);
         assert_eq!(config.rest_request_limit_per_second, 2);
@@ -114,6 +122,8 @@ mod tests {
         std::env::set_var("DOCKER_PORT_REST", "9876");
         std::env::set_var("STORAGE_HOST_GRPC", "test_host_grpc");
         std::env::set_var("STORAGE_PORT_GRPC", "12345");
+        std::env::set_var("GIS_HOST_GRPC", "test_host_grpc");
+        std::env::set_var("GIS_PORT_GRPC", "12342");
         std::env::set_var("LOG_CONFIG", "config_file.yaml");
         std::env::set_var("REST_CONCURRENCY_LIMIT_PER_SERVICE", "255");
         std::env::set_var("REST_REQUEST_LIMIT_PER_SECOND", "255");
@@ -130,6 +140,8 @@ mod tests {
         assert_eq!(config.docker_port_rest, 9876);
         assert_eq!(config.storage_port_grpc, 12345);
         assert_eq!(config.storage_host_grpc, String::from("test_host_grpc"));
+        assert_eq!(config.gis_host_grpc, String::from("test_host_grpc"));
+        assert_eq!(config.gis_port_grpc, 12342);
         assert_eq!(config.log_config, String::from("config_file.yaml"));
         assert_eq!(config.rest_concurrency_limit_per_service, 255);
         assert_eq!(config.rest_request_limit_per_second, 255);

--- a/server/src/grpc/client.rs
+++ b/server/src/grpc/client.rs
@@ -2,6 +2,7 @@
 use tokio::sync::OnceCell;
 
 // FIXME: import other microservices' GRPC clients instead, this is just an example.
+use svc_gis_client_grpc::prelude::*;
 use svc_storage_client_grpc::prelude::Clients;
 
 pub(crate) static CLIENTS: OnceCell<GrpcClients> = OnceCell::const_new();
@@ -22,8 +23,11 @@ pub async fn get_clients() -> &'static GrpcClients {
 /// Struct to hold all gRPC client connections
 #[derive(Clone, Debug)]
 pub struct GrpcClients {
-    /// FIXME: add the correct clients here
+    /// grpc client for svc-storage
     pub storage: Clients,
+
+    /// grpc client for svc-gis
+    pub gis: GisClient,
 }
 
 impl GrpcClients {
@@ -33,6 +37,7 @@ impl GrpcClients {
 
         GrpcClients {
             storage: storage_clients,
+            gis: GisClient::new_client(&config.gis_host_grpc, config.gis_port_grpc, "gis"),
         }
     }
 }

--- a/server/src/grpc/server.rs
+++ b/server/src/grpc/server.rs
@@ -1,6 +1,6 @@
 //! gRPC server implementation
 
-/// module generated from proto/svc-template-rust-grpc.proto
+/// module generated from proto/svc-itest-grpc.proto
 mod grpc_server {
     #![allow(unused_qualifications, missing_docs)]
     tonic::include_proto!("grpc");
@@ -28,7 +28,7 @@ impl RpcService for ServerImpl {
         &self,
         request: Request<ReadyRequest>,
     ) -> Result<Response<ReadyResponse>, Status> {
-        grpc_info!("(is_ready) template_rust server.");
+        grpc_info!("(is_ready) itest server.");
         grpc_debug!("(is_ready) [{:?}].", request);
         let response = ReadyResponse { ready: true };
         Ok(Response::new(response))
@@ -39,8 +39,8 @@ impl RpcService for ServerImpl {
 ///
 /// # Examples
 /// ```
-/// use svc_template_rust::grpc::server::grpc_server;
-/// use svc_template_rust::Config;
+/// use svc_itest::grpc::server::grpc_server;
+/// use svc_itest::Config;
 /// async fn example() -> Result<(), tokio::task::JoinError> {
 ///     let config = Config::default();
 ///     tokio::spawn(grpc_server(config, None)).await
@@ -91,7 +91,7 @@ impl RpcService for ServerImpl {
         &self,
         request: Request<ReadyRequest>,
     ) -> Result<Response<ReadyResponse>, Status> {
-        grpc_warn!("(is_ready MOCK) template_rust server.");
+        grpc_warn!("(is_ready MOCK) itest server.");
         grpc_debug!("(is_ready MOCK) [{:?}].", request);
         let response = ReadyResponse { ready: true };
         Ok(Response::new(response))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn load_logger_config_from_file(config_file: &str) -> Result<(), Strin
 ///
 /// ## axum
 /// ```
-/// use svc_template_rust::shutdown_signal;
+/// use svc_itest::shutdown_signal;
 /// pub async fn server() {
 ///     let app = axum::Router::new();
 ///     axum::Server::bind(&"0.0.0.0:8000".parse().unwrap())
@@ -93,7 +93,7 @@ pub async fn load_logger_config_from_file(config_file: &str) -> Result<(), Strin
 ///
 /// ## tonic
 /// ```
-/// use svc_template_rust::shutdown_signal;
+/// use svc_itest::shutdown_signal;
 /// pub async fn server() {
 ///     let (_, health_service) = tonic_health::server::health_reporter();
 ///     tonic::transport::Server::builder()
@@ -104,7 +104,7 @@ pub async fn load_logger_config_from_file(config_file: &str) -> Result<(), Strin
 ///
 /// ## using a shutdown signal channel
 /// ```
-/// use svc_template_rust::shutdown_signal;
+/// use svc_itest::shutdown_signal;
 /// pub async fn server() {
 ///     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 ///     let (_, health_service) = tonic_health::server::health_reporter();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
 //! Main function starting the server and initializing dependencies.
 
 use log::info;
-use svc_template_rust::*;
+use svc_itest::*;
 
 /// Main entry point: starts gRPC Server on specified address and port
 #[tokio::main]

--- a/server/src/rest/api.rs
+++ b/server/src/rest/api.rs
@@ -8,19 +8,19 @@ pub use rest_types::*;
 
 use crate::grpc::client::GrpcClients;
 use axum::{extract::Extension, Json};
+use chrono::Utc;
 use hyper::StatusCode;
-
+use svc_gis_client_grpc::client::{Coordinates, UpdateVertiportsRequest, Vertiport};
+use svc_gis_client_grpc::prelude::GisServiceClient;
 use svc_storage_client_grpc::prelude::*;
-// gRPC client types
-// use svc_scheduler_client_grpc::prelude::*;
-// ...
+use uuid::Uuid;
 
 /// Provides a way to tell a caller if the service is healthy.
 /// Checks dependencies, making sure all connections can be made.
 #[utoipa::path(
     get,
     path = "/health",
-    tag = "svc-template-rust",
+    tag = "svc-itest",
     responses(
         (status = 200, description = "Service is healthy, all dependencies running."),
         (status = 503, description = "Service is unhealthy, one or more dependencies unavailable.")
@@ -33,17 +33,14 @@ pub async fn health_check(
 
     let mut ok = true;
 
-    // FIXME - update/ uncomment this with the right dependencies.
-    // This health check is to verify that ALL dependencies of this
-    // microservice are running.
     if grpc_clients
         .storage
-        .adsb
+        .vertiport
         .is_ready(ReadyRequest {})
         .await
         .is_err()
     {
-        let error_msg = "svc-storage adsb unavailable.".to_string();
+        let error_msg = "svc-storage vertiport unavailable.".to_string();
         rest_error!("(health_check) {}.", &error_msg);
         ok = false;
     }
@@ -60,61 +57,251 @@ pub async fn health_check(
     }
 }
 
-/// Example REST API function
+/// Add a vertiport to storage and GIS
 #[utoipa::path(
-    post,
-    path = "/template/example",
-    tag = "svc-template-rust",
-    request_body = ExampleRequest,
+    put,
+    path = "/demo/vertiport",
+    tag = "svc-itest",
+    request_body = AddVertiportRequest,
     responses(
         (status = 200, description = "Request successful.", body = String),
         (status = 500, description = "Request unsuccessful."),
     )
 )]
-pub async fn example(
-    Extension(mut _grpc_clients): Extension<GrpcClients>,
-    Json(payload): Json<ExampleRequest>,
+pub async fn add_vertiport(
+    Extension(grpc_clients): Extension<GrpcClients>,
+    Json(payload): Json<AddVertiportRequest>,
 ) -> Result<Json<String>, StatusCode> {
     rest_debug!("(query_vertiports) entry.");
 
-    // Example request to outside gRPC client
+    let schedule: Option<String> = Some(
+        "\
+        DTSTART:20221020T180000Z;DURATION:PT14H
+        RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+        DTSTART:20221022T000000Z;DURATION:PT24H
+        RRULE:FREQ=WEEKLY;BYDAY=SA,SU"
+            .to_string(),
+    );
 
-    // // Build request
-    // let degree_range: f32 = 2.0;
-    // let filter = AdvancedSearchFilter::search_between(
-    //     "latitude".to_owned(),
-    //     (payload.latitude + degree_range).to_string(),
-    //     (payload.latitude - degree_range).to_string(),
-    // )
-    // .and_between(
-    //     "longitude".to_owned(),
-    //     (payload.longitude + degree_range).to_string(),
-    //     (payload.longitude - degree_range).to_string(),
-    // );
-    // let request = tonic::Request::new(filter);
+    let points: Vec<GeoPoint> = payload
+        .vertices
+        .iter()
+        .map(|vx| GeoPoint {
+            latitude: vx.0,
+            longitude: vx.1,
+        })
+        .collect();
 
-    // // Get client
-    // let result = grpc_clients.storage.get_client().await;
-    // let Some(mut client) = result else {
-    //     let error_msg = "svc-storage unavailable.".to_string();
-    //     rest_error!("(query_vertiports) {}", &error_msg);
-    //     return Err(StatusCode::SERVICE_UNAVAILABLE);
-    // };
+    let data = vertiport::Data {
+        name: payload.label.clone(),
+        description: "".to_string(),
+        geo_location: Some(GeoPolygon {
+            exterior: Some(GeoLineString { points }),
+            interiors: vec![],
+        }),
+        schedule: schedule.clone(),
+        created_at: None,
+        updated_at: None,
+    };
 
-    // // Make request, process response
-    // let response = client.search(request).await;
-    // match response {
-    //     Ok(response) => {
-    //         rest_info!("(example) response: {:?}", response);
-    //         Ok(Json(format!("{}!", payload.id)))
-    //     }
-    //     Err(e) => {
-    //         rest_error!("(example) error: {}", e);
-    //         Err(StatusCode::INTERNAL_SERVER_ERROR)
-    //     }
-    // }
+    let vertiport_id = grpc_clients
+        .storage
+        .vertiport
+        .insert(data)
+        .await
+        .map_err(|e| {
+            rest_error!("(add_vertiport) Error: {}.", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .into_inner()
+        .object
+        .ok_or_else(|| {
+            rest_error!("(add_vertiport) Error: no object returned.");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .id;
 
-    Ok(Json(format!("{}!", payload.id)))
+    for pad in &payload.pads {
+        let data = vertipad::Data {
+            vertiport_id: vertiport_id.clone(),
+            name: pad.label.clone(),
+            geo_location: Some(GeoPoint {
+                latitude: pad.centroid_latitude,
+                longitude: pad.centroid_longitude,
+            }),
+            enabled: true,
+            occupied: false,
+            schedule: schedule.clone(),
+            created_at: None,
+            updated_at: None,
+        };
+
+        grpc_clients
+            .storage
+            .vertipad
+            .insert(data)
+            .await
+            .map_err(|e| {
+                rest_error!("(add_vertiport) Error: {}.", e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    let vertiports = vec![Vertiport {
+        identifier: vertiport_id.clone(),
+        label: Some(payload.label.clone()),
+        vertices: payload
+            .vertices
+            .iter()
+            .map(|vx| Coordinates {
+                latitude: vx.0,
+                longitude: vx.1,
+            })
+            .collect(),
+        altitude_meters: 0.0,
+        timestamp_network: Some(Utc::now().into()),
+    }];
+
+    let request = UpdateVertiportsRequest { vertiports };
+
+    grpc_clients
+        .gis
+        .update_vertiports(request)
+        .await
+        .map_err(|e| {
+            rest_error!("(add_vertiport) Error: {}.", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(vertiport_id))
+}
+
+// /// Example REST API function
+// #[utoipa::path(
+//     delete,
+//     path = "/demo/vertiport",
+//     tag = "svc-itest",
+//     request_body = String,
+//     responses(
+//         (status = 200, description = "Request successful.", body = String),
+//         (status = 500, description = "Request unsuccessful."),
+//     )
+// )]
+// pub async fn delete_vertiport(
+//     Extension(mut grpc_clients): Extension<GrpcClients>,
+//     Json(payload): Json<String>,
+// ) -> Result<Json<String>, StatusCode> {
+//     rest_debug!("(query_vertiports) entry.");
+
+//     const schedule = Some("\
+//         DTSTART:20221020T180000Z;DURATION:PT14H
+//         RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+//         DTSTART:20221022T000000Z;DURATION:PT24H
+//         RRULE:FREQ=WEEKLY;BYDAY=SA,SU".to_string()
+//     );
+
+//     let data = vertiport::Data {
+//         name: payload.label.clone(),
+//         description: "".to_string(),
+//         geo_location: None,
+//         schedule,
+//         created_at: None,
+//         updated_at: None,
+//     }
+
+//     let vertiport_id = grpc_clients
+//         .storage
+//         .vertiport
+//         .insert(data)
+//         .await
+//         .map_err(|e| {
+//             rest_error!("(add_vertiport) Error: {}.", e);
+//             StatusCode::INTERNAL_SERVER_ERROR
+//         })?
+//         .into_inner()
+//         .id;
+
+//     for pad in &payload.pads {
+//         let data = vertipad::Data {
+//             vertiport_id: vertiport_id.clone(),
+//             name: pad.label.clone(),
+//             geo_location: Some(GeoPoint {
+//                 latitude: pad.centroid_latitude,
+//                 longitude: pad.centroid_longitude,
+//             }),
+//             enabled: true,
+//             occupied: false,
+//             schedule: schedule.clone(),
+//             created_at: None,
+//             updated_at: None,
+//         };
+
+//         grpc_clients
+//             .storage
+//             .vertipad
+//             .insert(data)
+//             .await
+//             .map_err(|e| {
+//                 rest_error!("(add_vertiport) Error: {}.", e);
+//                 StatusCode::INTERNAL_SERVER_ERROR
+//             })?;
+//     }
+
+//     Ok(Json(format!("{}!", vertiport_id)))
+// }
+
+/// Add aircraft to storage
+#[utoipa::path(
+    put,
+    path = "/demo/aircraft",
+    tag = "svc-itest",
+    request_body = AddAircraftRequest,
+    responses(
+        (status = 200, description = "Request successful.", body = String),
+        (status = 500, description = "Request unsuccessful."),
+    )
+)]
+pub async fn add_aircraft(
+    Extension(grpc_clients): Extension<GrpcClients>,
+    Json(payload): Json<AddAircraftRequest>,
+) -> Result<Json<String>, StatusCode> {
+    rest_debug!("(add_aircraft) entry.");
+
+    let schedule: Option<String> = Some(
+        "\
+        DTSTART:20221020T180000Z;DURATION:PT14H
+        RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+        DTSTART:20221022T000000Z;DURATION:PT24H
+        RRULE:FREQ=WEEKLY;BYDAY=SA,SU"
+            .to_string(),
+    );
+
+    let aircraft_id = grpc_clients
+        .storage
+        .vehicle
+        .insert(vehicle::Data {
+            vehicle_model_id: Uuid::new_v4().to_string(),
+            registration_number: payload.registration_number.clone(),
+            serial_number: Uuid::new_v4().to_string(),
+            description: Some(payload.nickname.clone()),
+            hangar_id: Some(payload.hangar_id),
+            schedule,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| {
+            rest_error!("(add_aircraft) Error: {}.", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .into_inner()
+        .object
+        .ok_or_else(|| {
+            rest_error!("(add_aircraft) Error: no object returned.");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .id;
+
+    Ok(Json(aircraft_id))
 }
 
 #[cfg(test)]

--- a/server/src/rest/mod.rs
+++ b/server/src/rest/mod.rs
@@ -12,13 +12,16 @@ use utoipa::OpenApi;
 #[openapi(
     paths(
         api::add_vertiport,
-        api::add_aircraft
+        api::add_vertipad,
+        api::add_aircraft,
+        api::add_user,
     ),
     components(
         schemas(
             api::rest_types::AddVertiportRequest,
+            api::rest_types::AddVertipadRequest,
             api::rest_types::AddAircraftRequest,
-            api::rest_types::Vertipad
+            api::rest_types::AddUserRequest,
         )
     ),
     tags(

--- a/server/src/rest/mod.rs
+++ b/server/src/rest/mod.rs
@@ -11,15 +11,18 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        // rest_api::query_flight
+        api::add_vertiport,
+        api::add_aircraft
     ),
     components(
         schemas(
-            api::rest_types::ExampleRequest
+            api::rest_types::AddVertiportRequest,
+            api::rest_types::AddAircraftRequest,
+            api::rest_types::Vertipad
         )
     ),
     tags(
-        (name = "svc-template-rust", description = "svc-template-rust REST API")
+        (name = "svc-itest", description = "svc-itest REST API")
     )
 )]
 struct ApiDoc;

--- a/server/src/rest/server.rs
+++ b/server/src/rest/server.rs
@@ -78,7 +78,8 @@ pub async fn rest_server(
     //
     let app = Router::new()
         .route("/health", routing::get(api::health_check)) // MUST HAVE
-        .route("/template/example", routing::post(api::example))
+        .route("/demo/vertiport", routing::put(api::add_vertiport))
+        .route("/demo/aircraft", routing::put(api::add_aircraft))
         .layer(
             CorsLayer::new()
                 .allow_origin(cors_allowed_origin)

--- a/server/src/rest/server.rs
+++ b/server/src/rest/server.rs
@@ -79,7 +79,9 @@ pub async fn rest_server(
     let app = Router::new()
         .route("/health", routing::get(api::health_check)) // MUST HAVE
         .route("/demo/vertiport", routing::put(api::add_vertiport))
+        .route("/demo/vertipad", routing::put(api::add_vertipad))
         .route("/demo/aircraft", routing::put(api::add_aircraft))
+        .route("/demo/user", routing::put(api::add_user))
         .layer(
             CorsLayer::new()
                 .allow_origin(cors_allowed_origin)

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -1,6 +1,6 @@
 //! Integration Tests
 use lib_common::log_macros;
-use svc_template_rust::*;
+use svc_itest::*;
 
 log_macros!("it", "test");
 
@@ -15,9 +15,9 @@ fn get_log_string(function: &str, name: &str) -> String {
 #[tokio::test]
 async fn test_server_requests_and_logs() {
     use logtest::Logger;
-    use svc_template_rust::grpc::server::*;
+    use svc_itest::grpc::server::*;
 
-    let name = "template_rust";
+    let name = "itest";
 
     // Start the logger.
     let mut logger = Logger::start();


### PR DESCRIPTION
Add endpoints for adding vertiports, vertipads, aircraft, and users.

In some cases, handles pushing data to svc-storage and svc-gis